### PR TITLE
Improve visual style of RMLdoc presentation

### DIFF
--- a/custom_style.css
+++ b/custom_style.css
@@ -1,0 +1,82 @@
+/* General Body Styles */
+body {
+  font-family: 'Droid Serif', serif;
+  font-size: 18px; /* Slightly larger base font size */
+  line-height: 1.6;
+  color: #333; /* Dark grey for text */
+  background-color: #fdfdfd; /* Very light grey background */
+}
+
+/* Headings */
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Yanone Kaffeesatz', sans-serif;
+  color: #007bff; /* A modern blue for headings */
+  font-weight: normal;
+  margin-top: 20px;
+  margin-bottom: 10px;
+}
+
+h1 { font-size: 2.5em; }
+h2 { font-size: 2em; }
+h3 { font-size: 1.75em; }
+
+/* Links */
+a {
+  color: #0056b3; /* A darker blue for links */
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+/* Images */
+img {
+  max-width: 100%; /* Ensure images are responsive */
+  height: auto;
+  display: block; /* Helps with margin control */
+  margin: 20px auto; /* Center images by default */
+  border: 1px solid #ddd; /* Light grey border */
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); /* Subtle shadow */
+  padding: 5px; /* Some spacing between image and border */
+  background-color: #fff; /* White background for the padding area */
+}
+
+/* Code Blocks and Inline Code */
+.remark-code, pre > code { /* remark.js uses .remark-code for blocks, pre > code is a common fallback */
+  font-family: 'Ubuntu Mono', monospace;
+  background-color: #f0f0f0; /* Light grey background for code blocks */
+  padding: 15px;
+  border-radius: 5px;
+  font-size: 0.9em;
+  line-height: 1.4;
+  overflow-x: auto; /* Allow horizontal scrolling for long code lines */
+  display: block; /* Ensure it takes full width */
+}
+
+.remark-inline-code { /* For inline code snippets */
+  font-family: 'Ubuntu Mono', monospace;
+  background-color: #e9ecef; /* Slightly different background for inline code */
+  padding: 0.2em 0.4em;
+  border-radius: 3px;
+  font-size: 0.85em;
+  color: #c7254e; /* A reddish color for inline code, common practice */
+}
+
+/* Slide specific adjustments for remark.js */
+.remark-slide-content {
+  padding: 20px 40px; /* Add some padding around slide content */
+}
+
+/* Center and middle alignment (if remark.js classes need help) */
+.center {
+  text-align: center;
+}
+.middle {
+  vertical-align: middle;
+}
+
+/* Remove the default remark.js slide number */
+.remark-slide-number {
+  display: none;
+}

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
       }
       .remark-code, .remark-inline-code { font-family: 'Ubuntu Mono'; }
     </style>
+    <link rel="stylesheet" type="text/css" href="custom_style.css">
   </head>
   <body>
     <textarea id="source">
@@ -85,7 +86,7 @@ rdfs:label "Ana Iglesias-Molina" .
 ```
 Output:
 
-<img src="author.png" alt="100%" width="100%" border="2px">
+<img src="author.png" alt="100%" width="100%">
 ---
 # RMLdoc Metadata: Dataset
 ```turtle
@@ -100,7 +101,7 @@ schema:description "RML mapping with a subset of
 the GTFS-Madrid-Bench mapping for CSV files.".
 ```
 Output:
-<img src="met_dataset.png" alt="200px" width="100%" border="2px">
+<img src="met_dataset.png" alt="200px" width="100%">
 ---
 # RML visualization: Namespaces
 ```turtle
@@ -108,7 +109,7 @@ Output:
 ```
 Output:
 
-<img src="namespaces.png" alt="100%" width="100%" border="2px">
+<img src="namespaces.png" alt="100%" width="100%">
 ---
 # RML visualization: Source
 ```turtle
@@ -121,7 +122,7 @@ Output:
 ```
 Output:
 
-<img src="source.png" alt="100%" width="100%" border="2px">
+<img src="source.png" alt="100%" width="100%">
 ---
 # RML visualization: Subject
 ```turtle
@@ -132,23 +133,23 @@ rr:subjectMap [
 ```
 Output:
 
-<img src="subject.png" alt="100%" width="100%" border="2px">
+<img src="subject.png" alt="100%" width="100%">
 ---
 # RML visualization: Predicate Object
 Output:
 
-<img src="po.png" alt="100%" width="100%" border="2px">
+<img src="po.png" alt="100%" width="100%">
 ---
 # RDF triples visualization
 Output:
 
-<img src="rdf_triples.png" alt="100%" width="100%" border="2px">
+<img src="rdf_triples.png" alt="100%" width="100%">
 ---
 # Join Condition visualization
 Output:
 
-<img src="join.png" alt="100%" width="100%" border="2px">
-<img src="join2.png" alt="100%" width="100%" border="2px">
+<img src="join.png" alt="100%" width="100%">
+<img src="join2.png" alt="100%" width="100%">
 ---
 class: center, middle
 That's all folks (for now)!


### PR DESCRIPTION
This commit introduces a custom CSS stylesheet (`custom_style.css`) to enhance the visual appearance of the `index.html` remark.js presentation.

Key changes include:
- Added `custom_style.css` with new rules for typography, colors, image presentation, and code block styling.
- Linked `custom_style.css` into `index.html`.
- Removed outdated inline `border="2px"` attributes from `<img>` tags, deferring styling to the external CSS.

The new styling provides a more modern and visually appealing look for the presentation slides.